### PR TITLE
License to kill (pods)

### DIFF
--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -470,7 +470,10 @@ def main(argv):
     ##########################################################################
     kube_config = parse_kubeconfig(args)
     k8s_client = K8sClient(kube_config=kube_config)
-    k8s_inventory = K8sInventory(k8s_client=k8s_client)
+    k8s_inventory = K8sInventory(
+        k8s_client=k8s_client,
+        delete_pods=args.use_pod_delete_instead_of_ssh_kill
+    )
 
     ##########################################################################
     # CLOUD DRIVER

--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -49,6 +49,18 @@ def parse_kubeconfig(args):
     """
     logger = logging.getLogger(__name__)
     kube_config = None
+    expanded_home_kube_config_path = os.path.expanduser(KUBECONFIG_DEFAULT_PATH)
+    if args.kubeconfig:
+        kube_config = args.kubeconfig
+        logger.info("Creating kubernetes client with config %s from --kubeconfig flag", kube_config)
+    elif os.environ.get("KUBECONFIG"):
+        kube_config = os.path.expanduser(os.environ.get("KUBECONFIG"))
+        logger.info("Creating kubernetes client with config %s from KUBECONFIG env var", kube_config)
+    elif os.path.exists(expanded_home_kube_config_path):
+        kube_config = expanded_home_kube_config_path
+        logger.info("Creating kubernetes client with config %s (path found for backwards compatibility)", kube_config)
+    else:
+        logger.info("Creating kubernetes client with in-cluster config")
     return kube_config
 
 def add_kubernetes_options(parser):

--- a/powerfulseal/cli/__main__.py
+++ b/powerfulseal/cli/__main__.py
@@ -71,6 +71,13 @@ def add_kubernetes_options(parser):
         help='Location of kube-config file',
         type=os.path.expanduser
     )
+    args_kubernetes.add_argument(
+        '--use-pod-delete-instead-of-ssh-kill',
+        help='If set, will not require SSH (will delete pods instead)',
+        default=False,
+        action='store_true',
+    )
+
 def add_ssh_options(parser):
     # SSH
     args_ssh = parser.add_argument_group('SSH settings')

--- a/powerfulseal/k8s/k8s_client.py
+++ b/powerfulseal/k8s/k8s_client.py
@@ -145,3 +145,16 @@ class K8sClient():
             namespace=namespace,
             label_selector=selector,
         ).items
+
+    def delete_pods(self, pods):
+        """
+            https://github.com/kubernetes-incubator/client-python/blob/master/kubernetes/docs/
+            CoreV1Api.md#delete_namespaced_pod
+            Delete all pods synchronously
+        """
+        for pod in pods:
+            self.client_corev1api.delete_namespaced_pod(
+                name=pod.name,
+                namespace=pod.namespace,
+                grace_period_seconds=0
+            )

--- a/powerfulseal/k8s/k8s_inventory.py
+++ b/powerfulseal/k8s/k8s_inventory.py
@@ -24,10 +24,11 @@ class K8sInventory():
         Also manages cache.
     """
 
-    def __init__(self, k8s_client, logger=None):
+    def __init__(self, k8s_client, delete_pods=False, logger=None):
         self.k8s_client = k8s_client
         self._cache_namespaces = []
         self._cache_last = None
+        self.delete_pods = delete_pods
         self.logger = logger or logging.getLogger(__name__)
         self.last_pods = []
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name='powerfulseal',
-    version='2.4.1',
+    version='2.5.0',
     author='Mikolaj Pawlikowski',
     author_email='mikolaj@pawlikowski.pl',
     url='https://github.com/bloomberg/powerfulseal',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name='powerfulseal',
-    version='2.5.0',
+    version='2.6.0',
     author='Mikolaj Pawlikowski',
     author_email='mikolaj@pawlikowski.pl',
     url='https://github.com/bloomberg/powerfulseal',

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -67,6 +67,7 @@ EXAMPLE_POD_SCHEMA = {
 def pod_scenario():
     inventory = MagicMock()
     k8s_inventory = MagicMock()
+    k8s_inventory.delete_pods = False
     executor = RemoteExecutor()
     return PodScenario(
         name="test scenario",


### PR DESCRIPTION
If set, `--use-pod-delete-instead-of-ssh-kill` will try to use delete pods, instead of sshing and killing the pods via `docker kill`.

Closes https://github.com/bloomberg/powerfulseal/issues/162